### PR TITLE
v0.1.4

### DIFF
--- a/JamfBackupRestoreFunctions.ps1
+++ b/JamfBackupRestoreFunctions.ps1
@@ -11,7 +11,7 @@
     Author         : Jorge Suarez
     Prerequisite   : PowerShell
     Dependencies   : Requires access to Jamf Pro API
-    Version        : 0.1.3
+    Version        : 0.1.4
     Contributors   : Cyril Niklaus, wewenttothemoon
 
 .COMPONENT
@@ -30,21 +30,35 @@
     - File system operations
 #>
 function Get-JamfToken {
+    # Function to get a Jamf authentication token using either OAuth or Basic auth
     param (
-        [string]$BaseUrl = $Config.BaseUrl,
-        [string]$Username = $Config.Username,
-        [string]$Password = $Config.Password,
-        [string]$ClientId = $Config.ClientId,
-        [string]$ClientSecret = $Config.ClientSecret
+        [Parameter(Mandatory = $true)]
+        [string]$BaseUrl = $Config.BaseUrl, # Base URL of the Jamf instance
+        [string]$Username = $Config.Username, # Username for Basic auth
+        [string]$Password = $Config.Password, # Password for Basic auth
+        [string]$ClientId = $Config.ClientId, # Client ID for OAuth
+        [string]$ClientSecret = $Config.ClientSecret  # Client secret for OAuth
     )
 
+    Write-Host "PSJamfBackupRestore 🚀`n" -ForegroundColor Green
+
+    Write-Host "BaseUrl: [$BaseUrl]" -ForegroundColor Green
+
     if ($ClientId -and $ClientSecret) {
+        Write-Host "ClientId: [$ClientId]" -ForegroundColor Green
+        Write-Host "ClientSecret: [REDACTED]" -ForegroundColor Green
+        # Use OAuth authentication if client credentials are provided
         $tokenUrl = "$BaseUrl/api/oauth/token"
-        $body = "client_id=$ClientId&client_secret=$ClientSecret&grant_type=client_credentials"
+        $body = "client_id=$ClientId"
+        $body += "&client_secret=$ClientSecret"
+        $body += "&grant_type=client_credentials"
         $headers = @{ "Content-Type" = "application/x-www-form-urlencoded" }
     } elseif ($Username -and $Password) {
+        Write-Host "Username: [$Username]" -ForegroundColor Green
+        Write-Host "Password: [REDACTED]" -ForegroundColor Green
+        # Use Basic authentication if username/password are provided
         $tokenUrl = "$BaseUrl/api/v1/auth/token"
-        $base64Auth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("$($Username):$Password"))
+        $base64Auth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes("$($Username):$($Password)"))
         $headers = @{
             "Authorization" = "Basic $base64Auth"
             "Accept"        = "application/json"
@@ -53,15 +67,34 @@ function Get-JamfToken {
         throw "Must provide either Username/Password or ClientId/ClientSecret."
     }
 
+    Write-Host "Obtaining Jamf API token..." -ForegroundColor Cyan -NoNewline
+
     try {
-        $response = Invoke-WebRequest -Uri $tokenUrl -Method Post -Body $body -Headers $headers -UseBasicParsing
+        # Make the token request
+        $tokenSplat = @{
+            Uri             = $tokenUrl
+            Method          = 'Post'
+            Body            = $body
+            Headers         = $headers
+            UseBasicParsing = $true
+        }
+        $response = Invoke-WebRequest @tokenSplat
+        # Extract token from response, handling both OAuth and Basic auth response formats
         $token = ($response.Content | ConvertFrom-Json).PSObject.Properties["access_token", "token"].Where({ $_.Value }).Value
+        # Output welcome message with config settings and credentials redacted
+
+        Write-Host " - ✅"
         return $token
     } catch {
-        throw "Failed to obtain token: $_"
+        if ($_.Exception.Response.StatusCode -eq 401) {
+            Write-Host " - ❌ Unauthorized access. Check your credentials." -ForegroundColor Red
+        } else {
+            throw "Unexpected Error: $_"
+        }
     }
 }
 function Test-AndRenewAPIToken {
+    # Function to test if current API token is valid and renew if needed
     param (
         [string]$BaseUrl = $Config.BaseUrl,
         [string]$ApiVersion = "v1",
@@ -69,18 +102,29 @@ function Test-AndRenewAPIToken {
     )
 
     try {
-        $response = Invoke-JamfApiCall -BaseUrl $BaseUrl -ApiVersion $ApiVersion -Endpoint "auth/keep-alive" -Method "POST" -Token $Token
+        # Attempt to keep the current token alive
+        $keepAliveSplat = @{
+            BaseUrl    = $BaseUrl
+            ApiVersion = $ApiVersion
+            Endpoint   = "auth/keep-alive"
+            Method     = "POST"
+            Token      = $Token
+        }
+        $response = Invoke-JamfApiCall @keepAliveSplat
+        # If successful, update the token in config
         if ($response.token) {
             $Config.Token = $response.token
         } else {
             throw "No token returned from keep-alive request."
         }
     } catch {
+        # If keep-alive fails, get a new token
         Write-Host "Attempting to refresh token..."
         $Config.Token = Get-JamfToken -BaseUrl $BaseUrl
     }
 }
 function Invoke-JamfApiCall {
+    # Function to make API calls to Jamf Pro
     param (
         [string]$BaseUrl = $Config.BaseUrl,
         [string]$ApiVersion = $Config.ApiVersion,
@@ -91,18 +135,29 @@ function Invoke-JamfApiCall {
         [switch]$XML
     )
 
+    # Validate token exists
     if (-not $Token) { throw "No token provided." }
 
-    $fullUrl = Get-JamfApiUrl -BaseUrl $BaseUrl -ApiVersion $ApiVersion -Endpoint $Endpoint
+    # Build the full API URL
+    $urlSplat = @{
+        BaseUrl    = $BaseUrl
+        ApiVersion = $ApiVersion
+        Endpoint   = $Endpoint
+    }
+    $fullUrl = Get-JamfApiUrl @urlSplat
+
+    # Set content type based on XML switch
     $contentType = if ($XML) { "application/xml" } else { "application/json" }
     $accept = if ($XML) { "text/xml" } else { "application/json" }
 
+    # Prepare request headers
     $headers = @{
         "Authorization" = "Bearer $Token"
         "Content-Type"  = $contentType
         "Accept"        = $accept
     }
 
+    # Build API request parameters
     $apiSplat = @{
         URI             = $fullUrl
         Method          = $Method
@@ -110,20 +165,23 @@ function Invoke-JamfApiCall {
         UseBasicParsing = $true
     }
     
+    # Add body if provided
     if ($Body) {
         $apiSplat.Add("Body", $Body)
     }
 
     try {
-        
+        # Make the API request
         $response = Invoke-WebRequest @apiSplat
 
+        # Return response based on format
         if ($XML) {
             return $response.Content
         } else {
             return ($response.Content | ConvertFrom-Json)
         }
     } catch {
+        # Handle token expiration
         if ($_.Exception.Response.StatusCode -eq 401) {
             Write-Host "Token expired. Renewing token..."
             $Config.Token = Get-JamfToken -BaseUrl $BaseUrl
@@ -131,6 +189,7 @@ function Invoke-JamfApiCall {
             $apiSplat["Headers"] = $headers
 
             try {
+                # Retry request with new token
                 $response = Invoke-WebRequest @apiSplat
 
                 if ($XML) {
@@ -146,40 +205,56 @@ function Invoke-JamfApiCall {
         }
     }
 }
-
 function Get-JamfApiUrl {
+    # Function to construct Jamf API URLs based on version and endpoint
     param (
-        [string]$BaseUrl,
-        [string]$ApiVersion,
-        [string]$Endpoint
+        [string]$BaseUrl, # Base URL of the Jamf instance
+        [string]$ApiVersion, # API version to use (v1, v2, v3, or classic)
+        [string]$Endpoint      # API endpoint to call
     )
+    # Return appropriate URL format based on API version
     switch ($ApiVersion) {
-        "v1" { "$BaseUrl/api/v1/$Endpoint" }
-        "v2" { "$BaseUrl/api/v2/$Endpoint" }
-        "classic" { "$BaseUrl/JSSResource/$Endpoint" }
+        "v1" { "$BaseUrl/api/v1/$Endpoint" }      # Modern v1 API format
+        "v2" { "$BaseUrl/api/v2/$Endpoint" }      # Modern v2 API format 
+        "v3" { "$BaseUrl/api/v3/$Endpoint" }      # Modern v3 API format
+        "classic" { "$BaseUrl/JSSResource/$Endpoint" }  # Legacy API format
         default { throw "Invalid ApiVersion. Use 'v1', 'v2', or 'classic'." }
     }
 }
 function Format-XML {
     param (
-        [string]$FilePath,
-        [string]$OutputPath = $FilePath
+        [string]$FilePath, # Path to the input XML file
+        [string]$OutputPath = $FilePath    # Path for the formatted output, defaults to input path
     )
 
     try {
+        # Read the entire file as a single string
         $content = Get-Content -Path $FilePath -Raw
+
+        # Remove any non-printable characters except tab, newline, and carriage return
         $cleanContent = $content -replace '[^\x09\x0A\x0D -~]', ''
+
+        # Convert the cleaned string to XML object
         $xml = [xml]$cleanContent
+
+        # Create XML writer with UTF-8 encoding
         $xmlWriter = New-Object System.Xml.XmlTextWriter($OutputPath, [System.Text.Encoding]::UTF8)
+
+        # Configure writer to use indented format
         $xmlWriter.Formatting = [System.Xml.Formatting]::Indented
-        $xmlWriter.Indentation = 4
+        $xmlWriter.Indentation = 4    # Set indent to 4 spaces
+
+        # Save the formatted XML to file
         $xml.Save($xmlWriter)
+
+        # Clean up by closing the writer
         $xmlWriter.Close()
     } catch {
         Write-Error "Failed to format XML: $_"
     }
 }
 function Ensure-DirectoryExists {
+    # Creates a directory if it doesn't exist
     param (
         [string]$DirectoryPath
     )
@@ -188,14 +263,16 @@ function Ensure-DirectoryExists {
     }
 }
 function Get-SanitizedDisplayName {
+    # Sanitizes object names by replacing non-alphanumeric chars with underscores
     param (
         [string]$Id,
         [string]$Name
     )
     $sanitizedName = $Name -replace '[^\x30-\x39\x41-\x5A\x61-\x7A]+', '_'
-    return "$Id_$sanitizedName"
+    return "$($id)_$sanitizedName"
 }
 function Download-JamfObject {
+    # Downloads and saves Jamf objects with their associated files
     param (
         [string]$Id,
         [string]$Resource,
@@ -203,24 +280,88 @@ function Download-JamfObject {
     )
 
     try {
-        # Check and renew the token if necessary
+        # Validate token status before proceeding
         Test-AndRenewAPIToken -BaseUrl $Config.BaseUrl -Token $Config.Token
         
+        # Get object details from Jamf
         $jamfObject = Get-JamfObject -Id $Id -Resource $Resource
         $extension = if ($Resource -eq "computer-prestages") { "json" } else { "xml" }
         $displayName = Get-SanitizedDisplayName -Id $Id -Name $jamfObject.name
+
+        # Define resources that can be organized by site
+        $siteBasedResources = @(
+            "computergroups",
+            "computers",
+            "macapplications",
+            "mobiledeviceapplications",
+            "mobiledeviceconfigurationprofiles",
+            "mobiledevicegroups",
+            "osxconfigurationprofiles",
+            "policies",
+            "restrictedsoftware"
+        )
+
+        $subfolder = ""
+        $targetDir = $DownloadDirectory  # default target directory
+
         if ($jamfObject.plist) {
-            $plistFilePath = Join-Path -Path $DownloadDirectory -ChildPath "$($id)_$displayName.plist"
+            # Parse XML content
+            [xml]$xml = $jamfObject.plist
+
+            # Set subfolder based on group type (smart vs static)
+            if ($Resource -in @("computergroups", "mobiledevicegroups")) {
+                $subfolder = if ($xml.SelectSingleNode("//is_smart").InnerText -eq 'true') { "smart" } else { "static" }
+            } 
+            # Organize by site if applicable
+            elseif ($siteBasedResources -contains $Resource) {
+                $siteName = switch ($Resource) {
+                    "computergroups" { $xml.computer_group.site.name }
+                    "computers" { $xml.computer.general.site.name }
+                    "macapplications" { $xml.mac_application.general.site.name }
+                    "mobiledeviceapplications" { $xml.mobile_device_application.general.site.name }
+                    "mobiledeviceconfigurationprofiles" { $xml.mobile_device_configuration_profile.general.site.name }
+                    "mobiledevicegroups" { $xml.mobile_device_group.site.name }
+                    "osxconfigurationprofiles" { $xml.os_x_configuration_profile.general.site.name }
+                    "policies" { $xml.policy.general.site.name }
+                    "restrictedsoftware" { $xml.restricted_software.general.site.name }
+                }
+
+                # Set site-based subfolder if site exists and isn't 'NONE'
+                if (-not [string]::IsNullOrWhiteSpace($siteName)) {
+                    $subfolder = if ($siteName -ne 'NONE') { $siteName }
+                }
+            }
+
+            # Create and use subfolder if specified
+            if ($subfolder) {
+                $targetDir = Join-Path -Path $DownloadDirectory -ChildPath $subfolder
+            }
+
+            # Save plist file
+            Ensure-DirectoryExists -DirectoryPath $targetDir
+            $plistFilePath = Join-Path -Path $targetDir -ChildPath "$displayName.plist"
             $jamfObject.plist | Out-File -FilePath $plistFilePath -Encoding utf8
             Format-XML -FilePath $plistFilePath
         }
+
+        # Save payload file if it exists
         if ($jamfObject.payload) {
-            $payloadFilePath = Join-Path -Path $DownloadDirectory -ChildPath "$($id)_$displayName.$extension"
+            Ensure-DirectoryExists -DirectoryPath $targetDir
+            $payloadFilePath = Join-Path -Path $targetDir -ChildPath "$displayName.$extension"
             $jamfObject.payload | Out-File -FilePath $payloadFilePath -Encoding utf8
-            if ($extension -eq "xml") { Format-XML -FilePath $payloadFilePath }
+            if ($extension -eq "xml") {
+                Format-XML -FilePath $payloadFilePath
+            }
         }
+
+        # Save script content if it exists
         if ($jamfObject.script) {
-            $scriptFilePath = Join-Path -Path $DownloadDirectory -ChildPath "$($id)_$displayName.sh"
+            # Remove .sh extension if present in display name
+            if ($displayName -like "*.sh") {
+                $displayName = $displayName -replace '\.sh$', ''
+            }
+
+            $scriptFilePath = Join-Path -Path $DownloadDirectory -ChildPath "$displayName.sh"
             $jamfObject.script | Out-File -FilePath $scriptFilePath -Encoding utf8
         }
     } catch {
@@ -229,26 +370,42 @@ function Download-JamfObject {
 }
 function Get-JamfObject {
     param (
-        [string]$Id,
-        [string]$Resource
+        [string]$Id, # Unique identifier of the Jamf object
+        [string]$Resource   # Type of resource (e.g., policies, scripts, computer-prestages)
     )
 
-    $apiVersion = if ($Resource -eq "computer-prestages") { "v2" } else { "classic" }
+    # Determine API version - computer-prestages uses v3, others use classic API
+    $apiVersion = if ($Resource -eq "computer-prestages") { "v3" } else { "classic" }
+    
+    # Build endpoint URL - computer-prestages has different format than other resources
     $endpoint = if ($Resource -eq "computer-prestages") { "$Resource/$Id" } else { "$Resource/id/$Id" }
+    
+    # Make API call - use XML format for classic API, JSON for v2/v3
     $response = Invoke-JamfApiCall -Endpoint $endpoint -Method "GET" -ApiVersion $apiVersion -XML:($apiVersion -eq "classic")
 
-    if ($apiVersion -eq "v2") {
+    # Handle modern API responses (v2/v3)
+    if ($apiVersion -match "v2|v3") {
         return @{
-            name    = $response.displayName
-            payload = $response | ConvertTo-Json -Depth 5
+            name    = $response.displayName    # Get display name from response
+            payload = $response | ConvertTo-Json -Depth 5  # Convert response to JSON
         }
-    } else {
-        $xml = [xml]$response
-        $payload = $xml.DocumentElement.FirstChild.payloads
-        $name = $xml.SelectSingleNode("//name").InnerText
-        $script = if ($Resource -eq "scripts") { $xml.SelectSingleNode("//script_contents").InnerText }
-        elseif ($Resource -eq "computerextensionattributes") { $xml.SelectSingleNode("//input_type/script").InnerText }
-        else { $null }
+    } 
+    # Handle classic API responses
+    else {
+        $xml = [xml]$response  # Convert response to XML object
+        $payload = $xml.DocumentElement.FirstChild.payloads  # Extract payloads
+        $name = $xml.SelectSingleNode("//name").InnerText   # Get object name
+
+        # Extract script content if it's a script-related resource
+        $script = if ($Resource -eq "scripts") { 
+            $xml.SelectSingleNode("//script_contents").InnerText 
+        } elseif ($Resource -eq "computerextensionattributes") { 
+            $xml.SelectSingleNode("//input_type/script").InnerText 
+        } else { 
+            $null 
+        }
+
+        # Return structured data including name, payload, original XML, and script content
         return @{
             name    = $name
             payload = $payload
@@ -259,30 +416,43 @@ function Get-JamfObject {
 }
 function Download-JamfObjects {
     param(
-        [string]$Id,
-        [string]$Resource,
-        [switch]$ClearExports
+        [string]$Id, # Optional: Specific object ID to download
+        [string]$Resource, # Required: Type of Jamf resource (e.g., policies, scripts)
+        [switch]$ClearExports       # Optional: Clear existing exports before downloading
     )
 
+    # Construct the download directory path using the resource type
     $downloadDirectory = Join-Path -Path $Config.DataFolder -ChildPath $Resource
 
+    # If ClearExports is specified, remove existing directory and its contents
     if ($ClearExports -and (Test-Path $downloadDirectory)) { Remove-Item $downloadDirectory -Recurse -Force }
+    # Create the download directory if it doesn't exist
     Ensure-DirectoryExists -DirectoryPath $downloadDirectory
 
     if ($Id) {
+        # Download a single object if ID is provided
         Download-JamfObject -Id $Id -Resource $Resource -DownloadDirectory $downloadDirectory
     } else {
-        Write-Output "Exporting all [$Resource] objects"
+        # Download all objects of the specified resource type
+        Write-Host "Exporting all [$Resource] objects" -NoNewline -ForegroundColor Cyan
+        # Get all object IDs for the specified resource
         $objectIds = Get-JamfObjectIds -Resource $Resource
-        foreach ($objectId in $objectIds) {
-            # Check and renew the token if necessary
-            Test-AndRenewAPIToken -BaseUrl $Config.BaseUrl -Token $Config.Token
+        try {
+            foreach ($objectId in $objectIds) {
+                # Verify token is valid before each download
+                Test-AndRenewAPIToken -BaseUrl $Config.BaseUrl -Token $Config.Token
             
-            Download-JamfObject -Id $objectId -Resource $Resource -DownloadDirectory $downloadDirectory
+                # Download each object individually
+                Download-JamfObject -Id $objectId -Resource $Resource -DownloadDirectory $downloadDirectory
+            }
+            Write-Host " - ✅" -ForegroundColor Green
+        } catch {
+            Write-Host " - ❌" -ForegroundColor Red
+            Write-Error "Failed to download objects for resource '$Resource': $_"
         }
+
     }
 }
-
 function Get-JamfObjectIds {
     param (
         [string]$Resource
@@ -290,7 +460,7 @@ function Get-JamfObjectIds {
 
     # Invoke the Jamf API call to get the response
     $apiVersion = switch ($Resource) {
-        "computer-prestages" { "v2" }
+        "computer-prestages" { "v3" }
         "patch-software-title-configurations" { "v2" }
         default { "classic" }
     }
@@ -312,10 +482,10 @@ function Get-JamfObjectIds {
     # Extract the value of the first NoteProperty and get the IDs
     $objects = $response.$($firstProperty.Name)
 
-    # Handle special case for smart groups filtering if applicable
-    if ($Resource -in "computergroups", "mobiledevicegroups") {
-        return ($objects | Where-Object { -not $_.is_smart }).id
-    }
+    # Uncomment if you want to export smart groups along with static groups
+    # if ($Resource -in "computergroups", "mobiledevicegroups") {
+    #     return ($objects | Where-Object { -not $_.is_smart }).id
+    # }
 
     # For computer-prestages, the property is 'results' with a nested structure
     if ($Resource -eq "computer-prestages") {
@@ -326,25 +496,38 @@ function Get-JamfObjectIds {
     return $objects.id
 }
 function Invalidate-JamfToken {
+    # Function to invalidate/revoke a Jamf API token
     param (
-        [string]$BaseUrl = $Config.BaseUrl,
-        [string]$ApiVersion = "v1",
-        [string]$Token = $Config.Token
+        [string]$BaseUrl = $Config.BaseUrl, # Base URL of the Jamf instance
+        [string]$ApiVersion = "v1", # API version to use
+        [string]$Token = $Config.Token           # Token to invalidate
     )
 
+    # Validate token exists
     if (-not $Token) {
         Write-Host "Token is required to invalidate." -ForegroundColor Red
         return $false
     }
 
     try {
-        $response = Invoke-JamfApiCall -BaseUrl $BaseUrl -ApiVersion $ApiVersion -Endpoint "auth/invalidate-token" -Method "POST" -Token $Token
+        # Make API call to invalidate token endpoint
+        $tokenSplat = @{
+            BaseUrl    = $BaseUrl
+            ApiVersion = $ApiVersion
+            Endpoint   = "auth/invalidate-token"
+            Method     = "POST"
+            Token      = $Token
+        }
+        $response = Invoke-JamfApiCall @tokenSplat
+        
+        # Check response - null indicates successful invalidation
         if ($null -eq $response) {
             Write-Host "Token successfully invalidated." -ForegroundColor Green
         } else {
             Write-Host "Unexpected response: $response" -ForegroundColor Yellow
         }
     } catch {
+        # Handle error cases
         if ($_.Exception.Response.StatusCode -eq 401) {
             Write-Host "Token already invalid or unauthorized." -ForegroundColor Yellow
         } else {
@@ -422,7 +605,7 @@ function Upload-JamfObjects {
 
         # Directory containing the objects to upload
         [Parameter(Mandatory = $false)]
-        [string]$SourceDirectory = (Join-Path (Get-Location) "JAMF_Backup/$Resource"),
+        [string]$SourceDirectory = (Join-Path (Get-Location) "$($Config.DataFolder)/$Resource"),
 
         # File pattern to match (defaults to XML files)
         [Parameter(Mandatory = $false)]

--- a/JamfBackupRestoreSampleUsage.ps1
+++ b/JamfBackupRestoreSampleUsage.ps1
@@ -36,7 +36,7 @@ $script:Config.Token = Get-JamfToken @tokenParams
     "mobiledeviceapplications",
     "macapplications"
 ) | ForEach-Object {
-    Download-JamfObjects -resource $_ -ClearExports -Verbose
+    Download-JamfObjects -resource $_ -ClearExports
 }
 
 # Download a single object from Jamf Pro

--- a/JamfBackupRestoreSampleUsage.ps1
+++ b/JamfBackupRestoreSampleUsage.ps1
@@ -9,9 +9,9 @@ if ($null -eq $script:Config) {
 
 # Request a Jamf token
 $tokenParams = @{
-    Username    = $script:Config.Username
-    Password    = $script:Config.Password
-    JamfProUrl  = $script:Config.JamfProUrl
+    Username = $script:Config.Username
+    Password = $script:Config.Password
+    BaseUrl  = $script:Config.BaseUrl
 }
 
 $script:Config.Token = Get-JamfToken @tokenParams
@@ -36,7 +36,7 @@ $script:Config.Token = Get-JamfToken @tokenParams
     "mobiledeviceapplications",
     "macapplications"
 ) | ForEach-Object {
-    Download-JamfObjects -resource $_ -ClearExports
+    Download-JamfObjects -resource $_ -ClearExports -Verbose
 }
 
 # Download a single object from Jamf Pro

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ if ($null -eq $script:Config) {
 $tokenParams = @{
     Username    = $script:Config.Username
     Password    = $script:Config.Password
-    JamfProUrl  = $script:Config.JamfProUrl
+    BaseUrl     = $script:Config.BaseUrl
 }
 $script:Config.Token = Get-JamfToken @tokenParams
 


### PR DESCRIPTION
This pull request updates the `JamfBackupRestoreFunctions.ps1` script and related files to improve functionality, enhance clarity, and introduce new features for interacting with the Jamf Pro API. Key changes include improved logging, better token handling, expanded API support, and enhanced file organization for downloaded objects.

### Enhancements to API Interaction and Token Handling:
* **Improved token logic in `Get-JamfToken`:** Added detailed logging for OAuth and Basic authentication, clarified parameter descriptions, and improved error handling for unauthorized access. [[1]](diffhunk://#diff-d268c318462f5955cb99d0a37d598b855e913d17675ebed1e50a63705ad301beR33-R61) [[2]](diffhunk://#diff-d268c318462f5955cb99d0a37d598b855e913d17675ebed1e50a63705ad301beR70-R127)
* **Enhanced token invalidation in `Invalidate-JamfToken`:** Added structured parameter validation and improved response handling for token invalidation.

### Expanded API Support:
* **Support for v3 API in `Get-JamfObject`:** Updated logic to handle v3 API for `computer-prestages` and improved payload extraction for both modern and classic APIs. [[1]](diffhunk://#diff-d268c318462f5955cb99d0a37d598b855e913d17675ebed1e50a63705ad301beL232-R408) [[2]](diffhunk://#diff-d268c318462f5955cb99d0a37d598b855e913d17675ebed1e50a63705ad301beL262-R463)
* **Improved `Get-JamfObjectIds`:** Updated to support v3 API for `computer-prestages` and clarified logic for filtering smart groups.

### Enhanced File Organization and Download Logic:
* **Enhanced `Download-JamfObject`:** Added logic to organize downloaded objects into subfolders based on site or group type, ensuring better structure for resources like `computergroups` and `policies`.
* **Improved `Download-JamfObjects`:** Added error handling and logging for bulk downloads, ensuring token validation before each operation.

### Miscellaneous Improvements:
* **Refined XML formatting in `Format-XML`:** Improved handling of non-printable characters and added comments for better readability.
* **Updated sample usage and documentation:** Replaced `JamfProUrl` with `BaseUrl` in both `JamfBackupRestoreSampleUsage.ps1` and `README.md` for consistency. [[1]](diffhunk://#diff-a93657db86efcf7230f43d4b80ace49a6551a276b74ea8cc5bad27ab012c6b52L14-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R66)